### PR TITLE
Add tooltip example in input

### DIFF
--- a/src/input/stories.js
+++ b/src/input/stories.js
@@ -5,11 +5,19 @@ import * as React from 'react';
 import {Form, Field} from 'react-final-form';
 import {storiesOf} from '@storybook/react';
 import withBaseui from '../with-baseui';
+import {styled} from 'baseui';
+import {StatefulTooltip} from 'baseui/tooltip';
 import {Button} from 'baseui/button';
 import Input from './index';
 import {minLength} from '../validate';
 
 const minLength3 = minLength(3);
+
+const FakeLink = styled('span', props => ({
+  borderBottom: `1px dotted ${props.$theme.colors.primary500}`,
+  color: props.$theme.colors.primary500,
+}));
+
 storiesOf('Input', module)
   .addDecorator(withBaseui)
   .add('Basic', () => (
@@ -22,7 +30,15 @@ storiesOf('Input', module)
           <Field
             name="firstName"
             component={Input}
-            caption="First name"
+            caption={
+              <React.Fragment>
+                You can use tooltips in many places, including inline text{' '}
+                <StatefulTooltip content="Tooltips display short messages.">
+                  <FakeLink>such as this</FakeLink>
+                </StatefulTooltip>
+                .
+              </React.Fragment>
+            }
             label="First name"
             validate={minLength3}
           />


### PR DESCRIPTION
Add a tooltip as a caption example:

![screen shot 2018-10-08 at 10 20 35 pm](https://user-images.githubusercontent.com/262105/46648126-6eb15780-cb48-11e8-8fac-7e6b63f33b82.png)
