### PR TITLE
Fix flow error caused by baseUI v7 upgrade

### DIFF
--- a/src/input/stories.js
+++ b/src/input/stories.js
@@ -15,10 +15,14 @@ import Readme from './README.md';
 
 const minLength3 = minLength(3);
 
-const FakeLink = styled('span', props => ({
-  borderBottom: `1px dotted ${props.$theme.colors.primary500}`,
-  color: props.$theme.colors.primary500,
-}));
+const FakeLink =
+  styled <
+  {} >
+  ('span',
+  props => ({
+    borderBottom: `1px dotted ${props.$theme.colors.primary500}`,
+    color: props.$theme.colors.primary500,
+  }));
 
 type AddressProps = {
   name: string,


### PR DESCRIPTION
Fixes this flow error:
```
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈src/input/stories.js:18:18

Could not decide which case to select, since case 2 [1] may work but if it doesn't case 3 [1] looks promising too. To
fix add a type annotation to return [2] or to props [3].

        src/input/stories.js
        15│
        16│ const minLength3 = minLength(3);
        17│
 [3][2] 18│ const FakeLink = styled('span', props => ({
        19│   borderBottom: `1px dotted ${props.$theme.colors.primary500}`,
        20│   color: props.$theme.colors.primary500,
        21│ }));
        22│
        23│ type AddressProps = {
        24│   name: string,

        node_modules/baseui/styles/styled.js.flow
    [1] 30│ type StyleFn = {
        31│   (string, StyleObject): StyletronComponent<{}>,
        32│
        33│   <Props>(
        34│     string,
        35│     ({$theme: ThemeT} & Props) => StyleObject,
        36│   ): StyletronComponent<Props>,
        37│
        38│   <Props, CustomTheme>(
        39│     string,
        40│     ({$theme: CustomTheme} & Props) => StyleObject,
        41│   ): StyletronComponent<Props>,
        42│
        43│   <Base: React.ComponentType<any>>(
        44│     Base,
        45│     StyleObject,
        46│   ): StyletronComponent<$Diff<React.ElementConfig<Base>, {className: any}>>,
        47│
        48│   <Base: React.ComponentType<any>, Props>(
        49│     Base,
        50│     ({$theme: ThemeT} & Props) => StyleObject,
        51│   ): StyletronComponent<
        52│     $Diff<React.ElementConfig<Base>, {className: any}> & Props,
        53│   >,
        54│
        55│   <Base: React.ComponentType<any>, Props, CustomTheme>(
        56│     Base,
        57│     ({$theme: CustomTheme} & Props) => StyleObject,
        58│   ): StyletronComponent<
        59│     $Diff<React.ElementConfig<Base>, {className: any}> & Props,
        60│   >,
        61│ };
```