### PR TITLE
Shift final-form* and react-final-form*  deps to devDeps, add peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baseui-final-form",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "main": "./dist-node-cjs/index.js",
   "module": "./dist-node-esm/index.js",
   "browser": {

--- a/package.json
+++ b/package.json
@@ -29,13 +29,6 @@
     "cover": "jest --coverage",
     "flow": "flow check"
   },
-  "dependencies": {
-    "final-form": "^4.16.1",
-    "final-form-arrays": "^1.1.2",
-    "react-final-form": "^6.3.0",
-    "react-final-form-arrays": "3.1.0",
-    "react-select": "^3.0.4"
-  },
   "resolutions": {
     "babel-core": "7.0.0-bridge.0"
   },
@@ -53,6 +46,7 @@
     "@storybook/addon-links": "^5.1.9",
     "@storybook/addons": "^5.1.9",
     "@storybook/react": "^5.1.9",
+    "@testing-library/react": "^8.0.1",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.0.2",
     "babel-loader": "^8.0.5",
@@ -69,6 +63,8 @@
     "eslint-plugin-react": "^7.12.3",
     "eslint-plugin-react-hooks": "^1.6.0",
     "eslint-plugin-sort-imports-es6-autofix": "^0.4.0",
+    "final-form": "^4.16.1",
+    "final-form-arrays": "^1.1.2",
     "flow-bin": "^0.102.0-rc",
     "husky": "^2.4.1",
     "jest": "^24.7.1",
@@ -76,16 +72,21 @@
     "prettier": "^1.18.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "@testing-library/react": "^8.0.1",
+    "react-final-form": "^6.3.0",
+    "react-final-form-arrays": "3.1.0",
     "rimraf": "^2.6.3",
     "storybook-readme": "^5.0.5",
     "styletron-engine-atomic": "^1.3.0",
     "styletron-react": "^5.1.3"
   },
   "peerDependencies": {
-    "baseui": "^7.5.0",
-    "react": "^16.8.0-0",
-    "react-dom": "^16.8.0-0"
+    "baseui": ">= 7.5.0 < 8",
+    "final-form": "^4.16.1",
+    "final-form-arrays": "^1.1.2",
+    "react": ">= 16.8.0 < 17",
+    "react-dom": ">= 16.8.0 < 17",
+    "react-final-form": ">= 6.3.0 < 7",
+    "react-final-form-arrays": ">= 3.1.0"
   },
   "keywords": [
     "react",
@@ -120,5 +121,8 @@
     "type": "git",
     "url": "https://github.com/kahwee/baseui-final-form.git"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "react-select": "^3.0.4"
+  }
 }


### PR DESCRIPTION
Chatted with @jonsadka on this.

It appears that he had v4 of react-final-form specified in his repo but it need to be v6 to align with a dependency within baseui-final-form. Gonna make this peerDep with @schnerd's suggestion.