### PR TITLE
New RadioGroup API adaptToRadioGroup

### DIFF
--- a/src/radio-group/README.md
+++ b/src/radio-group/README.md
@@ -1,0 +1,89 @@
+# Select
+
+This uses Baseui's RadioGroup and Radio.
+
+Check out [Baseui's RadioGroup examples](https://baseweb.design/components/radio/)
+
+Example of options:
+
+```json
+[
+  {"id": "apple", "label": "Apple", "emoji": "🍎"},
+  {"id": "avocado", "label": "Avocado", "emoji": "🥑"},
+  {"id": "banana", "label": "Banana", "emoji": "🍌"},
+  {"id": "kiwi", "label": "Kiwi", "disabled": true, "emoji": "🥝"},
+  {"id": "peach", "label": "Peach", "emoji": "🍑"},
+  {"id": "pineapple", "label": "Pineapple", "emoji": "🍍"},
+  {"id": "watermelon", "label": "Watermelon", "emoji": "🍉"}
+]
+```
+
+To use a single field:
+
+```js
+import RadioGroup from 'baseui-final-form/radio-group';
+
+const singleField = (
+  <Field
+    name="fruit"
+    component={RadioGroup}
+    caption="Please select a fruit"
+    label="My favorite fruit"
+    options={options}
+  />
+);
+```
+
+This is future-proof for future BaseWeb where RadioGroup no longer has `overrides`.
+
+```js
+import {
+  Radio as BaseuiRadio,
+  RadioGroup as BaseuiRadioGroup,
+} from 'baseui/radio';
+import {styled} from 'baseui';
+import {FormControl} from 'baseui/form-control';
+import {adaptToRadioGroup} from 'baseui-final-form/select';
+import {adaptToFormControl} from 'baseui-final-form/form-control';
+
+const withOverriddenFields = (
+  <Field
+    name="fruit"
+    caption="Please select a fruit (except watermelon which trigger validation error)"
+    label="My favorite fruit"
+    options={options}
+    validate={val => {
+      if (val === 'watermelon') {
+        return 'You cannot choose watermelon';
+      }
+    }}
+    render={props => (
+      <FormControl {...adaptToFormControl(props)}>
+        <BaseuiRadioGroup {...adaptToRadioGroup(props)}>
+          {options.map(option => (
+            <BaseuiRadio
+              value={option.id}
+              key={option.id}
+              overrides={{
+                // eslint-disable-next-line react/display-name
+                Label: ({$value}) => (
+                  <Block font="font400">
+                    Custom label for value: {$value}
+                  </Block>
+                ),
+                RadioMarkOuter: {
+                  style: ({$theme}) => ({
+                    backgroundColor: $theme.colors.positive,
+                  }),
+                },
+              }}
+            >
+              {option.label}
+            </BaseuiRadio>
+          ))}
+        </BaseuiRadioGroup>
+      </FormControl>
+    )}
+  />
+);
+```

--- a/src/radio-group/README.md
+++ b/src/radio-group/README.md
@@ -43,7 +43,7 @@ import {
 } from 'baseui/radio';
 import {styled} from 'baseui';
 import {FormControl} from 'baseui/form-control';
-import {adaptToRadioGroup} from 'baseui-final-form/select';
+import {adaptToRadioGroup} from 'baseui-final-form/radio-group';
 import {adaptToFormControl} from 'baseui-final-form/form-control';
 
 const withOverriddenFields = (

--- a/src/radio-group/README.md
+++ b/src/radio-group/README.md
@@ -1,4 +1,4 @@
-# Select
+# Radio group
 
 This uses Baseui's RadioGroup and Radio.
 

--- a/src/radio-group/__tests__/adapters.js
+++ b/src/radio-group/__tests__/adapters.js
@@ -1,0 +1,70 @@
+// @noflow
+import * as React from 'react';
+import {
+  Radio as BaseuiRadio,
+  RadioGroup as BaseuiRadioGroup,
+} from 'baseui/radio';
+import {Field, Form} from 'react-final-form';
+import {adaptToRadioGroup} from '../adapters';
+import {cleanup, fireEvent, render} from '@testing-library/react';
+import BaseuiProvider from '../../with-baseui';
+import options from '../../native-select/__tests__/__fixtures__/fruit-options.json';
+
+describe('radiogroup', () => {
+  afterEach(cleanup);
+
+  it('should be initialized as {}, then updated to peach, then be updated to apple', () => {
+    const mockSubmit = jest.fn();
+    const {container, getByLabelText} = render(
+      <BaseuiProvider>
+        <Form onSubmit={mockSubmit}>
+          {({handleSubmit}) => (
+            <form onSubmit={handleSubmit}>
+              <Field
+                name="fruit"
+                render={props => (
+                  <BaseuiRadioGroup {...adaptToRadioGroup(props)}>
+                    {options.map(option => (
+                      <BaseuiRadio value={option.id} key={option.id}>
+                        {option.label}
+                      </BaseuiRadio>
+                    ))}
+                  </BaseuiRadioGroup>
+                )}
+              />
+            </form>
+          )}
+        </Form>
+      </BaseuiProvider>
+    );
+    const formNode = container.querySelector('form');
+    const radioPeach = getByLabelText('Peach');
+    const radioApple = getByLabelText('Apple');
+    expect(radioPeach.checked).toBe(false);
+    expect(radioApple.checked).toBe(false);
+    fireEvent.submit(formNode);
+    expect(mockSubmit).toHaveBeenLastCalledWith(
+      {},
+      expect.anything(),
+      expect.any(Function)
+    );
+    fireEvent.click(radioPeach);
+    expect(radioPeach.checked).toBe(true);
+    expect(radioApple.checked).toBe(false);
+    fireEvent.submit(formNode);
+    expect(mockSubmit).toHaveBeenLastCalledWith(
+      {fruit: 'peach'},
+      expect.anything(),
+      expect.any(Function)
+    );
+    fireEvent.click(radioApple);
+    expect(radioPeach.checked).toBe(false);
+    expect(radioApple.checked).toBe(true);
+    fireEvent.submit(formNode);
+    expect(mockSubmit).toHaveBeenLastCalledWith(
+      {fruit: 'apple'},
+      expect.anything(),
+      expect.any(Function)
+    );
+  });
+});

--- a/src/radio-group/__tests__/index.js
+++ b/src/radio-group/__tests__/index.js
@@ -38,50 +38,6 @@ describe('radiogroup', () => {
     /* eslint-enable no-console */
   });
 
-  it('should be initialized as {}, then updated to peach, then be updated to apple', () => {
-    const mockSubmit = jest.fn();
-    const {container, getByLabelText} = render(
-      <BaseuiProvider>
-        <Form onSubmit={mockSubmit}>
-          {({handleSubmit}) => (
-            <form onSubmit={handleSubmit}>
-              <Field {...defaultProps} />
-            </form>
-          )}
-        </Form>
-      </BaseuiProvider>
-    );
-    const formNode = container.querySelector('form');
-    const radioPeach = getByLabelText('Peach');
-    const radioApple = getByLabelText('Apple');
-    expect(radioPeach.checked).toBe(false);
-    expect(radioApple.checked).toBe(false);
-    fireEvent.submit(formNode);
-    expect(mockSubmit).toHaveBeenLastCalledWith(
-      {},
-      expect.anything(),
-      expect.any(Function)
-    );
-    fireEvent.click(radioPeach);
-    expect(radioPeach.checked).toBe(true);
-    expect(radioApple.checked).toBe(false);
-    fireEvent.submit(formNode);
-    expect(mockSubmit).toHaveBeenLastCalledWith(
-      {fruit: 'peach'},
-      expect.anything(),
-      expect.any(Function)
-    );
-    fireEvent.click(radioApple);
-    expect(radioPeach.checked).toBe(false);
-    expect(radioApple.checked).toBe(true);
-    fireEvent.submit(formNode);
-    expect(mockSubmit).toHaveBeenLastCalledWith(
-      {fruit: 'apple'},
-      expect.anything(),
-      expect.any(Function)
-    );
-  });
-
   it('should be initialized as peach then be updated to apple', () => {
     const mockSubmit = jest.fn();
     const {container, getByLabelText} = render(

--- a/src/radio-group/adapters.js
+++ b/src/radio-group/adapters.js
@@ -1,0 +1,20 @@
+// @flow
+import {type FieldRenderProps} from 'react-final-form';
+import type {FieldRenderPropsMeta} from '../types';
+
+type AdaptToMultiSelectProps = {
+  meta: FieldRenderPropsMeta,
+} & FieldRenderProps;
+export function adaptToRadioGroup(props: {}) {
+  const {meta, input} = ((props: any): AdaptToMultiSelectProps);
+  return {
+    id: input.name,
+    value: input.value,
+    onChange: (ev: SyntheticInputEvent<HTMLInputElement>) => {
+      if (input.onChange) {
+        input.onChange(ev.target.value);
+      }
+    },
+    isError: meta.error && meta.touched,
+  };
+}

--- a/src/radio-group/index.js
+++ b/src/radio-group/index.js
@@ -1,25 +1,19 @@
 // @flow
 import * as React from 'react';
-import {type FieldRenderProps} from '../types.js';
 import {FormControl} from 'baseui/form-control';
 import {Radio, RadioGroup} from 'baseui/radio';
 import {adaptToFormControl} from '../form-control';
-import assignProps from '../util/assign-props';
+import {adaptToRadioGroup} from './adapters';
+import type {OptionT} from './types.js';
 
-export default function render(props: FieldRenderProps) {
-  const {inputProps, options, onChange} = assignProps(props);
-  if (!Array.isArray(options)) {
-    throw new Error('Missing options');
-  }
+type Props = {
+  options: Array<OptionT>,
+};
+export default function render(props: Props) {
   return (
     <FormControl {...adaptToFormControl(props)}>
-      <RadioGroup
-        {...inputProps}
-        onChange={(ev, item) => {
-          onChange(ev.target.value);
-        }}
-      >
-        {options.map((option, index) => {
+      <RadioGroup {...adaptToRadioGroup(props)}>
+        {props.options.map((option, index) => {
           return (
             <Radio value={option.id} {...option} key={index}>
               {option.label}
@@ -30,3 +24,5 @@ export default function render(props: FieldRenderProps) {
     </FormControl>
   );
 }
+
+export {adaptToRadioGroup};

--- a/src/radio-group/stories.js
+++ b/src/radio-group/stories.js
@@ -1,13 +1,17 @@
-/* eslint-env node */
 // @flow
-
 import * as React from 'react';
+import {
+  Radio as BaseuiRadio,
+  RadioGroup as BaseuiRadioGroup,
+} from 'baseui/radio';
 import {Block} from 'baseui/block';
 import {Button} from 'baseui/button';
 import {Field, Form} from 'react-final-form';
+import {FormControl} from 'baseui/form-control';
 import {action} from '@storybook/addon-actions';
+import {adaptToFormControl} from '../form-control';
 import {storiesOf} from '@storybook/react';
-import RadioGroup from './index';
+import RadioGroup, {adaptToRadioGroup} from './index';
 import options from '../native-select/__tests__/__fixtures__/fruit-options.json';
 
 storiesOf('RadioGroup', module)
@@ -40,19 +44,41 @@ storiesOf('RadioGroup', module)
         <form onSubmit={handleSubmit}>
           <Field
             name="fruit"
-            component={RadioGroup}
-            caption="Please select a fruit"
+            caption="Please select a fruit (except watermelon which trigger validation error)"
             label="My favorite fruit"
             options={options}
-            overrides={{
-              // eslint-disable-next-line react/display-name
-              Label: ({$value}) => (
-                <Block font="font400">Custom label for value: {$value}</Block>
-              ),
-              RadioMark: {
-                style: ({$theme}) => ({borderColor: $theme.colors.positive}),
-              },
+            validate={val => {
+              if (val === 'watermelon') {
+                return 'You cannot choose watermelon';
+              }
             }}
+            render={props => (
+              <FormControl {...adaptToFormControl(props)}>
+                <BaseuiRadioGroup {...adaptToRadioGroup(props)}>
+                  {options.map(option => (
+                    <BaseuiRadio
+                      value={option.id}
+                      key={option.id}
+                      overrides={{
+                        // eslint-disable-next-line react/display-name
+                        Label: ({$value}) => (
+                          <Block font="font400">
+                            Custom label for value: {$value}
+                          </Block>
+                        ),
+                        RadioMarkOuter: {
+                          style: ({$theme}) => ({
+                            backgroundColor: $theme.colors.positive,
+                          }),
+                        },
+                      }}
+                    >
+                      {option.label}
+                    </BaseuiRadio>
+                  ))}
+                </BaseuiRadioGroup>
+              </FormControl>
+            )}
           />
 
           <Button type="submit" disabled={pristine || invalid}>

--- a/src/radio-group/types.js
+++ b/src/radio-group/types.js
@@ -1,0 +1,5 @@
+// @flow
+export type OptionT = {
+  id?: string,
+  label?: string,
+};


### PR DESCRIPTION
Resolves #61

This is future-proof for future BaseWeb when RadioGroup no longer has `overrides`. This pattern lets the user continue to overwrite Baseui's `Radio`

```js
import {
  Radio as BaseuiRadio,
  RadioGroup as BaseuiRadioGroup,
} from 'baseui/radio';
import {styled} from 'baseui';
import {FormControl} from 'baseui/form-control';
import {adaptToRadioGroup} from 'baseui-final-form/radio-group';
import {adaptToFormControl} from 'baseui-final-form/form-control';

const withOverriddenFields = (
  <Field
    name="fruit"
    caption="Please select a fruit (except watermelon which trigger validation error)"
    label="My favorite fruit"
    options={options}
    validate={val => {
      if (val === 'watermelon') {
        return 'You cannot choose watermelon';
      }
    }}
    render={props => (
      <FormControl {...adaptToFormControl(props)}>
        <BaseuiRadioGroup {...adaptToRadioGroup(props)}>
          {options.map(option => (
            <BaseuiRadio
              value={option.id}
              key={option.id}
              overrides={{
                // eslint-disable-next-line react/display-name
                Label: ({$value}) => (
                  <Block font="font400">
                    Custom label for value: {$value}
                  </Block>
                ),
                RadioMarkOuter: {
                  style: ({$theme}) => ({
                    backgroundColor: $theme.colors.positive,
                  }),
                },
              }}
            >
              {option.label}
            </BaseuiRadio>
          ))}
        </BaseuiRadioGroup>
      </FormControl>
    )}
  />
);
```